### PR TITLE
Fix compilation on GHC 7.10

### DIFF
--- a/src/Language/Sexp/Printer.hs
+++ b/src/Language/Sexp/Printer.hs
@@ -23,7 +23,7 @@ printMach (Atom s)  = let es = escape s
     shouldQuote es = BS.null es
                      || BS.find (\c -> (c < 'A' || 'z' < c)
                                        && (c < '0' || '9' < c)
-                                       && not (c `elem` "-_+~<>='/*")) es /= Nothing
+                                       && not (c `elem` ("-_+~<>='/*" :: String))) es /= Nothing
 printMach (List xs) = makeList (map printMach xs)
 
 -- | Turn @["a", "(b)", "c"]@ into @(a (b) c)@.


### PR DESCRIPTION
Some type signatures when using elem are needed in order for sexp to compile on GHC 7.10.
For more information see: https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10